### PR TITLE
Add missing dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,7 @@
     "name": "chrome-app-serial",
     "version": "0.0.1",
     "dependencies": {
-        "bootstrap": "latest"
+        "bootstrap": "latest",
+        "jquery": "latest"
     }
 }


### PR DESCRIPTION
I encountered an error while testing this project out -- something like "Bootstrap's JavaScript requires jQuery."  Adding the dependency to bower.json seems to fix the issue.